### PR TITLE
Proper display of answers on Q/Index:  Answer order and Vote count display

### DIFF
--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -21,14 +21,14 @@
 
 <table class='aTable'>
 
-<% @answers.where(question_id:question['id']).each do |answer| %>
+<% @answers.where(question_id:question['id']).order('upvote - downvote DESC').each do |answer| %>
 
 <tr>
 
 	<td>
-		<button id="upvote" type="button" class="btn btn-success btn-sm btn-upvote"><div style="font-size:1.25em"<b>3</b></div></button>
+		<button id="upvote" type="button" class="btn btn-success btn-sm btn-upvote"><div style="font-size:1.25em"<b><%= answer['upvote'] %></b></div></button>
 	<br>
-		<button id="downvote" type="button" class="btn btn-danger btn-sm"><div style="font-size:1.25em"<b>1</b></div></button>
+		<button id="downvote" type="button" class="btn btn-danger btn-sm"><div style="font-size:1.25em"<b><%= answer['downvote'] %></b></div></button>
 	</td>
 	<td>
 		<%= answer['text'] %>


### PR DESCRIPTION
Closes issue #27 (Sorts answers on q/index by difference between upvote and downvote)
Closes issue #28 (Pulls database values for number of upvotes and downvotes instead of using fixed values)