### PR TITLE
Change page titles globally to Cliqr.  Closes issue #22.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Clique</title>
+  <title>Cliqr</title>
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>


### PR DESCRIPTION
Change page titles globally to Cliqr.  Closes issue #22 